### PR TITLE
fix devise functions

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -18,10 +18,15 @@ class Admin::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  def after_sign_out_path_for(resource_or_scope)
+    new_admin_session_path
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
-  #権限設定は一旦解除しています
-  #before_action :authenticate_admin!
+  before_action :authenticate_admin!,if: :admin_url
 
+  def admin_url
+    request.fullpath.include?("/admin")
+  end
 end


### PR DESCRIPTION
・before_action :authenticate_admin!, if:: admin_url(admin_urlメソッドを追加)にすることで、public側で制約を受けないように変更
・after_sign_out pathメソッドをadminのsessions_controllerに記載することでログイン後の遷移ページを修正
